### PR TITLE
Fixed nested promises in return types.

### DIFF
--- a/thread.ts
+++ b/thread.ts
@@ -204,8 +204,8 @@ export class Thread<T extends (...args: any) => any> extends EventEmitter {
      * Argument types must be serializable using the {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types structuredClone()} algorithm.
      * @returns A `Promise<ReturnType<T>>` that resolves to the return type of your callback function.
      */
-    public async run(...args: Parameters<T>): Promise<ReturnType<T>> {
-        return new Promise<ReturnType<T>>((resolve, reject) => {
+    public async run(...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> {
+        return new Promise<Awaited<ReturnType<T>>>((resolve, reject) => {
             // check if the worker has closed, and if it has, create a new one and update the function
             if (typeof this.worker === 'undefined') {
                 this.worker = new Worker(import.meta.dir + "/worker")

--- a/threadpool.ts
+++ b/threadpool.ts
@@ -226,7 +226,7 @@ export class ThreadPool<T extends (...args: any) => any> {
     }
 
     /** {@inheritDoc Thread.run} */
-    public async run(...args: Parameters<T>): Promise<ReturnType<T>> {
+    public async run(...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> {
 
         // run through a decision tree to select which thread to use, prevents just reusing the same thread over and over
         let winner: Thread<T> | undefined


### PR DESCRIPTION
Example: Thread.run() and ThreadPool.run() now return Promise<string> instead of Promise<Promise<string>>